### PR TITLE
Fix Mobile Toolbar Width

### DIFF
--- a/src/scss/10_foundations/_custom-icons.scss
+++ b/src/scss/10_foundations/_custom-icons.scss
@@ -36,7 +36,6 @@ svg.lucide-bookmark,
 svg.lucide-bug,
 svg.lucide-calendar,
 svg.lucide-check-circle-2,
-svg.lucide-check-square,
 svg.lucide-check,
 // svg.lucide-chevron-down,
 // svg.lucide-chevron-up,
@@ -45,7 +44,6 @@ svg.lucide-chevrons-up-down:is(.nav-action-button svg.lucide-chevrons-up-down),
 svg.lucide-clipboard-check,
 svg.lucide-clipboard-list,
 svg.lucide-clock,
-svg.lucide-code-2,
 svg.lucide-copy,
 svg.lucide-download-cloud,
 svg.lucide-edit-3,
@@ -76,7 +74,6 @@ svg.lucide-info,
 svg.lucide-layers,
 svg.lucide-layout-dashboard,
 svg.lucide-layout,
-svg.lucide-link,
 svg.lucide-list:not(.mobile-toolbar-option svg.lucide-list, .mobile-option-setting-item-option-icon svg.lucide-list),
 svg.lucide-lock,
 svg.lucide-maximize,
@@ -91,8 +88,6 @@ svg.lucide-pencil,
 // svg.lucide-pin,
 svg.lucide-plus-circle,
 svg.lucide-plus,
-svg.lucide-quote,
-svg.lucide-redo-2,
 svg.lucide-refresh-cw,
 svg.lucide-rotate-ccw,
 svg.lucide-rotate-cw,
@@ -105,12 +100,10 @@ svg.lucide-settings,
 svg.lucide-sliders-horizontal,
 svg.lucide-sort-asc,
 svg.lucide-sort-desc,
-svg.lucide-sticky-note,
 svg.lucide-tags,
 svg.lucide-terminal,
 svg.lucide-text,
 svg.lucide-trash-2,
-svg.lucide-undo-2,
 svg.lucide-wand-2,
 svg.lucide-x,
 svg.lucide-zap,
@@ -188,10 +181,6 @@ svg.lucide-check-circle-2 {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='m18.214,9.098c.387.394.381,1.027-.014,1.414l-4.426,4.345c-.783.768-1.791,1.151-2.8,1.151-.998,0-1.996-.376-2.776-1.129l-1.899-1.867c-.394-.387-.399-1.02-.012-1.414.386-.395,1.021-.4,1.414-.012l1.893,1.861c.776.75,2.001.746,2.781-.018l4.425-4.344c.393-.388,1.024-.381,1.414.013Zm5.786,2.902c0,6.617-5.383,12-12,12S0,18.617,0,12,5.383,0,12,0s12,5.383,12,12Zm-2,0c0-5.514-4.486-10-10-10S2,6.486,2,12s4.486,10,10,10,10-4.486,10-10Z'/%3E%3C/svg%3E%0A");
 }
 
-svg.lucide-check-square:not(.mobile-toolbar-option svg.lucide-check-square) {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Outline' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M19,0H5A5.006,5.006,0,0,0,0,5V19a5.006,5.006,0,0,0,5,5H19a5.006,5.006,0,0,0,5-5V5A5.006,5.006,0,0,0,19,0Zm3,19a3,3,0,0,1-3,3H5a3,3,0,0,1-3-3V5A3,3,0,0,1,5,2H19a3,3,0,0,1,3,3Z'/%3E%3Cpath d='M9.333,15.919,5.414,12A1,1,0,0,0,4,12H4a1,1,0,0,0,0,1.414l3.919,3.919a2,2,0,0,0,2.829,0L20,8.081a1,1,0,0,0,0-1.414h0a1,1,0,0,0-1.414,0Z'/%3E%3C/svg%3E%0A");
-}
-
 svg.lucide-check {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Outline' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M22.319,4.431,8.5,18.249a1,1,0,0,1-1.417,0L1.739,12.9a1,1,0,0,0-1.417,0h0a1,1,0,0,0,0,1.417l5.346,5.345a3.008,3.008,0,0,0,4.25,0L23.736,5.847a1,1,0,0,0,0-1.416h0A1,1,0,0,0,22.319,4.431Z'/%3E%3C/svg%3E%0A");
 }
@@ -206,10 +195,6 @@ svg.lucide-clipboard-list {
 
 svg.lucide-clock {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M12,24C5.383,24,0,18.617,0,12S5.383,0,12,0s12,5.383,12,12-5.383,12-12,12Zm0-22C6.486,2,2,6.486,2,12s4.486,10,10,10,10-4.486,10-10S17.514,2,12,2Zm1,10V6c0-.552-.448-1-1-1s-1,.448-1,1v5h-3c-.552,0-1,.448-1,1s.448,1,1,1h4c.552,0,1-.448,1-1Z'/%3E%3C/svg%3E%0A");
-}
-
-svg.lucide-code-2 {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M14.831,17c-.256,0-.512-.098-.707-.293-.391-.391-.391-1.023,0-1.414l2.583-2.583c.188-.189,.293-.44,.293-.708s-.104-.518-.293-.707l-2.583-2.584c-.391-.391-.391-1.024,0-1.414,.391-.391,1.023-.391,1.414,0l2.583,2.583c.566,.566,.879,1.32,.879,2.121s-.312,1.555-.879,2.122l-2.583,2.583c-.195,.195-.451,.293-.707,.293Zm-4.955-.298c.391-.391,.391-1.023,0-1.414l-2.583-2.583c-.189-.189-.293-.44-.293-.708s.104-.518,.293-.707l2.583-2.583c.391-.391,.391-1.023,0-1.414s-1.023-.391-1.414,0l-2.583,2.583c-.567,.567-.879,1.32-.879,2.122s.312,1.555,.879,2.122l2.583,2.583c.195,.195,.451,.293,.707,.293s.512-.098,.707-.293Zm14.124,2.298V5c0-2.757-2.243-5-5-5H5C2.243,0,0,2.243,0,5v14c0,2.757,2.243,5,5,5h14c2.757,0,5-2.243,5-5ZM19,2c1.654,0,3,1.346,3,3v14c0,1.654-1.346,3-3,3H5c-1.654,0-3-1.346-3-3V5c0-1.654,1.346-3,3-3h14Z'/%3E%3C/svg%3E");
 }
 
 svg.lucide-copy {
@@ -334,10 +319,6 @@ svg.lucide-layout-dashboard {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Outline' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M2,11H13a2,2,0,0,0,2-2V2a2,2,0,0,0-2-2H2A2,2,0,0,0,0,2V9A2,2,0,0,0,2,11ZM2,2H13V9H2Z'/%3E%3Cpath d='M22,0H19a2,2,0,0,0-2,2V9a2,2,0,0,0,2,2h3a2,2,0,0,0,2-2V2A2,2,0,0,0,22,0Zm0,9H19V2h3Z'/%3E%3Cpath d='M5,13H2a2,2,0,0,0-2,2v7a2,2,0,0,0,2,2H5a2,2,0,0,0,2-2V15A2,2,0,0,0,5,13Zm0,9H2V15H5Z'/%3E%3Cpath d='M22,13H11a2,2,0,0,0-2,2v7a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V15A2,2,0,0,0,22,13Zm0,9H11V15H22Z'/%3E%3C/svg%3E");
 }
 
-svg.lucide-link {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M7.835,16.17c-.23-.23-.446-.482-.641-.748-.325-.446-.227-1.072,.22-1.397,.446-.325,1.071-.227,1.397,.219,.129,.178,.274,.349,.437,.511,.803,.803,1.87,1.245,3.005,1.245s2.203-.442,3.005-1.245l5.5-5.5c1.657-1.657,1.657-4.354,0-6.011s-4.354-1.657-6.011,0l-1.058,1.058c-.391,.391-1.023,.391-1.414,0s-.391-1.023,0-1.414l1.058-1.058c2.437-2.438,6.402-2.438,8.839,0,2.437,2.437,2.437,6.402,0,8.839l-5.5,5.5c-1.18,1.181-2.75,1.831-4.419,1.831s-3.239-.65-4.418-1.83Zm-1.582,7.83c1.67,0,3.239-.65,4.419-1.831l1.058-1.058c.391-.39,.391-1.023,0-1.414-.39-.391-1.023-.39-1.414,0l-1.059,1.058c-.803,.803-1.87,1.245-3.005,1.245s-2.202-.442-3.005-1.245-1.245-1.87-1.245-3.005,.442-2.203,1.245-3.005l5.5-5.5c.803-.803,1.87-1.245,3.005-1.245s2.203,.442,3.005,1.245c.16,.161,.306,.332,.436,.51,.324,.447,.949,.547,1.397,.221,.447-.325,.546-.95,.221-1.397-.19-.262-.405-.513-.639-.747-1.181-1.182-2.751-1.832-4.42-1.832s-3.239,.65-4.419,1.831L1.834,13.331C.653,14.511,.003,16.081,.003,17.75c0,1.669,.65,3.239,1.831,4.419,1.18,1.181,2.749,1.831,4.419,1.831Z'/%3E%3C/svg%3E%0A");
-}
-
 svg.lucide-list:not(.mobile-toolbar-option svg.lucide-list, .mobile-option-setting-item-option-icon svg.lucide-list) {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' width='100%25' height='100%25' viewBox='0 0 24 24'%3E%3Cpath d='m19,1H5C2.243,1,0,3.243,0,6v12c0,2.757,2.243,5,5,5h14c2.757,0,5-2.243,5-5V6c0-2.757-2.243-5-5-5Zm3,17c0,1.654-1.346,3-3,3H5c-1.654,0-3-1.346-3-3V6c0-1.654,1.346-3,3-3h14c1.654,0,3,1.346,3,3v12Zm-3-11c0,.552-.448,1-1,1h-7c-.552,0-1-.448-1-1s.448-1,1-1h7c.552,0,1,.448,1,1Zm-11,0c0,.828-.672,1.5-1.5,1.5s-1.5-.672-1.5-1.5.672-1.5,1.5-1.5,1.5.672,1.5,1.5Zm11,5c0,.552-.448,1-1,1h-7c-.552,0-1-.448-1-1s.448-1,1-1h7c.552,0,1,.448,1,1Zm-11,0c0,.828-.672,1.5-1.5,1.5s-1.5-.672-1.5-1.5.672-1.5,1.5-1.5,1.5.672,1.5,1.5Zm11,5c0,.552-.448,1-1,1h-7c-.552,0-1-.448-1-1s.448-1,1-1h7c.552,0,1,.448,1,1Zm-11,0c0,.828-.672,1.5-1.5,1.5s-1.5-.672-1.5-1.5.672-1.5,1.5-1.5,1.5.672,1.5,1.5Z'/%3E%3C/svg%3E%0A");
 }
@@ -391,14 +372,6 @@ svg.lucide-plus {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Outline' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M17,11H13V7a1,1,0,0,0-1-1h0a1,1,0,0,0-1,1v4H7a1,1,0,0,0-1,1H6a1,1,0,0,0,1,1h4v4a1,1,0,0,0,1,1h0a1,1,0,0,0,1-1V13h4a1,1,0,0,0,1-1h0A1,1,0,0,0,17,11Z'/%3E%3C/svg%3E");
 }
 
-svg.lucide-quote {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Outline' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M8,4H4A4,4,0,0,0,0,8v4a2,2,0,0,0,2,2H7.91A6.006,6.006,0,0,1,2,19a1,1,0,0,0,0,2,8.009,8.009,0,0,0,8-8V6A2,2,0,0,0,8,4Z'/%3E%3Cpath d='M22,4H18a4,4,0,0,0-4,4v4a2,2,0,0,0,2,2h5.91A6.006,6.006,0,0,1,16,19a1,1,0,0,0,0,2,8.009,8.009,0,0,0,8-8V6A2,2,0,0,0,22,4Z'/%3E%3C/svg%3E%0A");
-}
-
-svg.lucide-redo-2 {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M16.9,14.723a1,1,0,0,0,1.414,0l4.949-4.95a2.5,2.5,0,0,0,0-3.536l-4.95-4.949A1,1,0,0,0,16.9,2.7L21.2,7,5,7H5a5,5,0,0,0-5,5v7a5.006,5.006,0,0,0,5,5H19a1,1,0,0,0,0-2H5a3,3,0,0,1-3-3V12A3,3,0,0,1,5,9H5L21.212,9,16.9,13.309A1,1,0,0,0,16.9,14.723Z'/%3E%3C/svg%3E");
-}
-
 svg.lucide-refresh-cw {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Outline' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M21.962,12.875A10.03,10.03,0,1,1,19.122,5H16a1,1,0,0,0-1,1h0a1,1,0,0,0,1,1h4.143A1.858,1.858,0,0,0,22,5.143V1a1,1,0,0,0-1-1h0a1,1,0,0,0-1,1V3.078A11.985,11.985,0,1,0,23.95,13.1a1.007,1.007,0,0,0-1-1.1h0A.982.982,0,0,0,21.962,12.875Z'/%3E%3C/svg%3E");
 }
@@ -448,10 +421,6 @@ svg.lucide-sort-desc {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M24,16c0,.553-.447,1-1,1H10c-.553,0-1-.447-1-1s.447-1,1-1h13c.553,0,1,.447,1,1Zm-14-4h10c.553,0,1-.447,1-1s-.447-1-1-1H10c-.553,0-1,.447-1,1s.447,1,1,1Zm0-5h7c.553,0,1-.447,1-1s-.447-1-1-1h-7c-.553,0-1,.447-1,1s.447,1,1,1Zm0-5h4c.553,0,1-.447,1-1s-.447-1-1-1h-4c-.553,0-1,.447-1,1s.447,1,1,1Zm-2.293,17.293l-1.707,1.707V1c0-.553-.447-1-1-1s-1,.447-1,1V21l-1.707-1.707c-.391-.391-1.023-.391-1.414,0s-.391,1.023,0,1.414l2.707,2.707c.39,.39,.902,.585,1.414,.585s1.024-.195,1.414-.585l2.707-2.707c.391-.391,.391-1.023,0-1.414s-1.023-.391-1.414,0Z'/%3E%3C/svg%3E%0A");
 }
 
-svg.lucide-sticky-note {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M19,0H5C2.24,0,0,2.24,0,5v14c0,2.76,2.24,5,5,5h11.34c1.34,0,2.59-.52,3.54-1.46l2.66-2.66c.94-.94,1.46-2.2,1.46-3.54V5c0-2.76-2.24-5-5-5ZM5,22c-1.65,0-3-1.35-3-3V5c0-1.65,1.35-3,3-3h14c1.65,0,3,1.35,3,3V15h-4c-1.65,0-3,1.35-3,3v4H5Zm13.46-.88c-.4,.4-.91,.68-1.46,.8v-3.93c0-.55,.45-1,1-1h3.93c-.12,.55-.4,1.06-.8,1.46l-2.66,2.66Z'/%3E%3C/svg%3E%0A");
-}
-
 svg.lucide-tags {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M7.707,9.256c.391,.391,.391,1.024,0,1.414-.391,.391-1.024,.391-1.414,0-.391-.391-.391-1.024,0-1.414,.391-.391,1.024-.391,1.414,0Zm13.852,6.085l-.565,.565c-.027,1.233-.505,2.457-1.435,3.399l-3.167,3.208c-.943,.955-2.201,1.483-3.543,1.487h-.017c-1.335,0-2.59-.52-3.534-1.464L1.882,15.183c-.65-.649-.964-1.542-.864-2.453l.765-6.916c.051-.456,.404-.819,.858-.881l6.889-.942c.932-.124,1.87,.193,2.528,.851l7.475,7.412c.387,.387,.697,.823,.931,1.288,.812-1.166,.698-2.795-.342-3.835L12.531,2.302c-.229-.229-.545-.335-.851-.292l-6.889,.942c-.549,.074-1.052-.309-1.127-.855-.074-.547,.309-1.051,.855-1.126L11.409,.028c.921-.131,1.869,.191,2.528,.852l7.589,7.405c1.946,1.945,1.957,5.107,.032,7.057Zm-3.438-1.67l-7.475-7.412c-.223-.223-.536-.326-.847-.287l-6.115,.837-.679,6.14c-.033,.303,.071,.601,.287,.816l7.416,7.353c.569,.57,1.322,.881,2.123,.881h.01c.806-.002,1.561-.319,2.126-.893l3.167-3.208c1.155-1.17,1.149-3.067-.014-4.229Z'/%3E%3C/svg%3E");
 }
@@ -466,10 +435,6 @@ svg.lucide-text {
 
 svg.lucide-trash-2 {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Outline' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M21,4H17.9A5.009,5.009,0,0,0,13,0H11A5.009,5.009,0,0,0,6.1,4H3A1,1,0,0,0,3,6H4V19a5.006,5.006,0,0,0,5,5h6a5.006,5.006,0,0,0,5-5V6h1a1,1,0,0,0,0-2ZM11,2h2a3.006,3.006,0,0,1,2.829,2H8.171A3.006,3.006,0,0,1,11,2Zm7,17a3,3,0,0,1-3,3H9a3,3,0,0,1-3-3V6H18Z'/%3E%3Cpath d='M10,18a1,1,0,0,0,1-1V11a1,1,0,0,0-2,0v6A1,1,0,0,0,10,18Z'/%3E%3Cpath d='M14,18a1,1,0,0,0,1-1V11a1,1,0,0,0-2,0v6A1,1,0,0,0,14,18Z'/%3E%3C/svg%3E");
-}
-
-svg.lucide-undo-2 {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' id='Layer_1' data-name='Layer 1' viewBox='0 0 24 24' width='100%25' height='100%25'%3E%3Cpath d='M22.535,8.46A4.965,4.965,0,0,0,19,7h0L2.8,7,7.1,2.7A1,1,0,0,0,5.682,1.288L.732,6.237a2.5,2.5,0,0,0,0,3.535l4.95,4.951A1,1,0,1,0,7.1,13.309L2.788,9,19,9h0a3,3,0,0,1,3,3v7a3,3,0,0,1-3,3H5a1,1,0,0,0,0,2H19a5.006,5.006,0,0,0,5-5V12A4.969,4.969,0,0,0,22.535,8.46Z'/%3E%3C/svg%3E");
 }
 
 svg.lucide-wand-2 {
@@ -579,10 +544,4 @@ svg.vault {
 // Edit Block Button
 .edit-block-button svg.lucide-code-2 {
     -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='lucide lucide-pen-line'%3E%3Cpath d='M12 20h9'/%3E%3Cpath d='M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z'/%3E%3C/svg%3E");
-}
-
-// Mobile Toolbar
-.mobile-toolbar-option svg.lucide-check-square,
-.mobile-option-setting-item-option-icon svg.lucide-check-square.lucide-check-square.lucide-check-square {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='lucide lucide-list-todo'%3E%3Crect x='3' y='5' width='6' height='6' rx='1'/%3E%3Cpath d='m3 17 2 2 4-4'/%3E%3Cpath d='M13 6h8'/%3E%3Cpath d='M13 12h8'/%3E%3Cpath d='M13 18h8'/%3E%3C/svg%3E");
 }

--- a/src/scss/10_foundations/palettes/_classic-original.scss
+++ b/src/scss/10_foundations/palettes/_classic-original.scss
@@ -1510,8 +1510,6 @@ body {
                                         0px 5px 14px -0.6px rgba(0, 0, 0, 0.09),
                                         0px 10px 20px -4.9px rgba(0, 0, 0, 0.02);
 
-        --mobile-toolbar-bg: color-mix(in srgb, var(--background-primary) 50%, var(--background-primary-alt));
-
         --navbar-shadow:    0px 4px 20px 0px rgba(0, 0, 0, 0.1),
                             0px 1px 4px 0px rgba(0, 0, 0, 0.05);
 
@@ -2651,8 +2649,6 @@ body {
         --mobile-sidebar-tablet-shadow: 0px 2px 6px -0.3px rgba(0, 0, 0, 0.2),
                                         0px 5px 14px -0.6px rgba(0, 0, 0, 0.19),
                                         0px 10px 20px -4.9px rgba(0, 0, 0, 0.12);
-
-        --mobile-toolbar-bg: color-mix(in srgb, var(--editor-bg-color) 50%, var(--background-primary-alt));
 
         --navbar-shadow:    0px 4px 20px 0px rgba(0, 0, 0, 0.4),
                             0px 1px 4px 0px rgba(0, 0, 0, 0.3);

--- a/src/scss/20_window/_toolbar.scss
+++ b/src/scss/20_window/_toolbar.scss
@@ -1,9 +1,7 @@
 /*────────── Toolbar ──────────*/
 
 .mobile-toolbar {
-    width: auto;
+    width: 100%;
     background: var(--mobile-toolbar-bg);
     border: 1px solid var(--background-modifier-border);
-    border-radius: var(--radius-l);
-    margin: calc(-1 * var(--size-2-3)) var(--size-4-2) var(--size-4-2) var(--size-4-2);
 }

--- a/src/scss/20_window/_toolbar.scss
+++ b/src/scss/20_window/_toolbar.scss
@@ -1,7 +1,0 @@
-/*────────── Toolbar ──────────*/
-
-.mobile-toolbar {
-    width: 100%;
-    background: var(--mobile-toolbar-bg);
-    border: 1px solid var(--background-modifier-border);
-}

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -6,7 +6,6 @@
 
 @use '20_window/divider';
 @use '20_window/navbar';
-@use '20_window/toolbar';
 @use '20_window/ribbon';
 @use '20_window/sidebar';
 @use '20_window/status-bar';


### PR DESCRIPTION
Removed custom styling and icons applied to the mobile toolbar so it is displayed properly and is no longer cut off.

My reasoning behind this is that some custom icons were not properly aligned due to inherent flaws in their design (a good example of this was with the undo/redo icons). I also think keeping the design as close to vanilla as possible will better future proof the toolbar and the theme in general.

Fixes #1