### PR TITLE
Fix Oversized Ribbon Icons

### DIFF
--- a/src/scss/10_foundations/_icon.scss
+++ b/src/scss/10_foundations/_icon.scss
@@ -6,10 +6,6 @@ body:not(.is-phone, .is-mobile) {
     .clickable-icon {
         --icon-size: var(--icon-s);
     }
-
-    .clickable-icon.side-dock-ribbon-action .svg-icon {
-        --icon-size: var(--ribbon-icon);
-    }
 } 
 
 // Mobile


### PR DESCRIPTION
Removed the reference to the `--ribbon-icon` variable deleted in #9.